### PR TITLE
Add `js2r-toggle-use-strict-<defun|module>` commands

### DIFF
--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -269,5 +269,18 @@ function."
                (when oneline?
                  (insert "\n"))))))))))
 
+(defun js2r-toggle-use-strict-module ()
+  "Toggle 'use strict' globally."
+  (interactive)
+  (save-excursion
+    (goto-char (point-min))
+    (save-match-data
+      (if (re-search-forward (concat "^" js2r--use-strict-regexp) nil t)
+          (progn (js2r--delete-match)
+                 (js2r--delete-blank-lines))
+        (insert (js2r--use-strict))
+        (unless (looking-at-p "\n[[:space:]]*$")
+          (insert "\n\n"))))))
+
 (provide 'js2r-conveniences)
 ;;; js2r-conveniences.el ends here

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -238,5 +238,36 @@ down in an object or array literal."
         (end-of-line)
         (delete-char -1))))
 
+(defun js2r-toggle-use-strict-defun ()
+  "Toggle 'use strict' in the current function.
+If `point' is not in a function, or FORCE-FILE is given, toggle
+'use strict' globally. Otherwise, toggle it in the current
+function."
+  (interactive)
+  (js2r--wait-for-parse
+   (let* ((fun (or (js2r--defun-at-point)
+                   (user-error "Not in a function")))
+          (body (js2-function-node-body fun)))
+     (unless (js2-block-node-p body)
+       (user-error "Function body must be a block"))
+     (save-excursion
+       (goto-char (js2-node-abs-pos body))
+       (save-match-data
+         (if (search-forward-regexp js2r--use-strict-regexp
+                                    (js2-node-abs-end body) t)
+             (progn (js2r--delete-match)
+                    (js2r--delete-blank-lines))
+           (goto-char (js2-node-abs-pos body))
+           (forward-char)
+           (let ((start (point))
+                 (oneline? (= (line-number-at-pos (js2-node-abs-end body))
+                              (line-number-at-pos (js2-node-abs-pos body)))))
+             (js2r--with-indentation
+               (insert "\n" (js2r--use-strict))
+               (unless (looking-at-p "\n[[:space:]]*$")
+                 (insert "\n"))
+               (when oneline?
+                 (insert "\n"))))))))))
+
 (provide 'js2r-conveniences)
 ;;; js2r-conveniences.el ends here

--- a/js2r-iife.el
+++ b/js2r-iife.el
@@ -25,8 +25,7 @@
 (require 'js2r-helpers)
 (require 'cl-lib)
 
-(defconst js2r--iife-regexp "[[:space:]]*(\\(?:function ([^)]*)\\|([^)]*) => {\\)")
-(defconst js2r--use-strict-regexp "[[:space:]]*\\(['\"]\\)use strict\\1")
+(defconst js2r--iife-regexp "[[:space:]]*(\\(?:function ([^)]*)\\|([^)]*)[[:space:]\n]*=>\\)[[:space:]\n]*{")
 
 (defun js2r-looking-at-iife-p ()
   "Check if `point' is `looking-at' an IIFE."
@@ -50,10 +49,7 @@ BEG and END are the start and end of the region, respectively."
                     ((or `function `function-inner) "function ()")
                     (`lambda "() =>"))
               " {\n")
-      (when strict (insert (pcase js2r-prefered-quote-type
-                             (1 "\"use strict\"")
-                             (2 "'use strict'"))
-                           ";\n"))
+      (when strict (insert (js2r--use-strict)))
       (goto-char end-marker)
       (unless (eq (char-before) ?\n)
         (insert "\n"))


### PR DESCRIPTION
`js2r-toggle-use-strict-defun` works in all function-like contexts (lambdas,
anonymous functions, functions, ...); `js2r-toggle-use-strict-module` currently
does not skip comments, like `js2r-wrap-buffer-in-iife`.
