### PR TITLE
Highlights minor mode

### DIFF
--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -132,6 +132,7 @@
 (require 'js2r-conditionals)
 (require 'js2r-conveniences)
 (require 'js2r-paredit)
+(require 'js2r-highlights)
 
 (defvar js2-refactor-mode-map
   (make-sparse-keymap)

--- a/js2r-highlights.el
+++ b/js2r-highlights.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(defun js2r--highlight-get-var-regions ()
+(defun js2r--hl-get-var-regions ()
   (let* ((current-node (js2r--local-name-node-at-point))
          (len (js2-node-len current-node)))
     (mapcar (lambda (beg)
@@ -15,7 +15,7 @@
     ((js2-regexp-node-p node) (js2-regexp-node-value node))
     (t (error "Not a constant node"))))
 
-(defun js2r--highlight-get-constant-regions (const)
+(defun js2r--hl-get-constant-regions (const)
   (let* ((regions (list))
          (type (js2-node-type const))
          (value (js2r--constant-node-value const)))
@@ -31,19 +31,81 @@
                      t))
     regions))
 
-(defun js2r--highlight-get-regions (pos)
+(defun js2r--hl-get-regions (pos)
   (let ((node (js2-node-at-point pos)))
     (cond
-      ((js2-name-node-p node) (js2r--highlight-get-var-regions))
+      ((js2-name-node-p node) (js2r--hl-get-var-regions))
       ((or (js2-string-node-p node)
            (js2-number-node-p node)
            (js2-regexp-node-p node))
-       (js2r--highlight-get-constant-regions node)))))
+       (js2r--hl-get-constant-regions node)))))
 
 (defun js2r-highlight-thing-at-point (pos)
   (interactive "d")
   (js2r-hl-forgetit)
-  (js2r--highlight-things (js2r--highlight-get-regions pos)))
+  (js2r--hl-things (or (js2r--hl-get-regions pos)
+                       (js2r--hl-get-regions (- pos 1)))))
+
+(defun js2r--hl-get-free-vars-regions (pos)
+  (let* ((node (js2-node-at-point pos))
+         (func (js2-mode-find-enclosing-fn node))
+         (regions (list)))
+    (cl-flet ((is-free? (node)
+                (cl-block is-free?      ; cl-flet bug?
+                  (let* ((name (js2-name-node-name node))
+                         (sym (if (symbolp name) name (intern name)))
+                         (p (js2-node-parent node)))
+                    (while p
+                      (when (js2-scope-p p)
+                        (when (cdr (assq sym (js2-scope-symbol-table p)))
+                          (return-from is-free? nil)))
+                      (when (eq p func)
+                        (return-from is-free? t))
+                      (setf p (js2-node-parent p)))))))
+      (js2-visit-ast
+       func
+       (lambda (node end-p)
+         (unless end-p
+           (when (and (js2r--local-name-node-p node)
+                      (not (and (js2-function-node-p func)
+                                (eq node (js2-function-node-name func))))
+                      (is-free? node))
+             (push `((begin . ,(js2-node-abs-pos node))
+                     (end . ,(js2-node-abs-end node)))
+                   regions)))
+         t)))
+    regions))
+
+(defun js2r-highlight-free-vars (pos)
+  (interactive "d")
+  (js2r-hl-forgetit)
+  (js2r--hl-things (js2r--hl-get-free-vars-regions pos)))
+
+(defun js2r--hl-get-exits-regions (pos)
+  (let* ((node (js2-node-at-point pos))
+         (func (js2-mode-find-parent-fn node))
+         (regions (list)))
+    (unless func
+      (error "Not inside a function"))
+    (js2-visit-ast
+     func
+     (lambda (node end-p)
+       (cond
+         ((js2-function-node-p node)
+          (eq node func))
+         ((not end-p)
+          (when (or (js2-throw-node-p node)
+                    (js2-return-node-p node))
+            (push `((begin . ,(js2-node-abs-pos node))
+                    (end . ,(js2-node-abs-end node)))
+                  regions))
+          t))))
+    regions))
+
+(defun js2r-highlight-exits (pos)
+  (interactive "d")
+  (js2r-hl-forgetit)
+  (js2r--hl-things (js2r--hl-get-exits-regions pos)))
 
 (defun js2r-hl--get-overlays (rev)
   (sort (remove-if-not (lambda (ov)
@@ -58,7 +120,7 @@
 (defun js2r-hl-forgetit ()
   (interactive)
   (remove-overlays (point-min) (point-max) 'js2r-highlights t)
-  (js2r--highlight-mode 0))
+  (js2r--hl-mode 0))
 
 (defun js2r-hl-move-next ()
   (interactive)
@@ -77,34 +139,34 @@
         (goto-char (overlay-start i))
         (throw 'done nil)))))
 
-(defun js2r--highlight-things (things &rest options)
+(defun js2r--hl-things (things &rest options)
   (let ((line-only (plist-get options :line-only))
         (things (sort things
                       (lambda (a b)
                         (< (cdr (assq 'begin a))
                            (cdr (assq 'begin b)))))))
     (cond
-      (things
-       (loop for ref in things
-             for beg = (cdr (assq 'begin ref))
-             for end = (if line-only
-                           (save-excursion
-                            (goto-char beg)
-                            (end-of-line)
-                            (point))
-                           (cdr (assq 'end ref)))
-             do (let ((ovl (make-overlay beg end)))
-                  (overlay-put ovl 'face 'highlight)
-                  (overlay-put ovl 'evaporate t)
-                  (overlay-put ovl 'js2r-highlights t)))
-       (message "%d places highlighted" (length things))
-       (js2r--highlight-mode 1))
+      (things (cl-loop
+                 for ref in things
+                 for beg = (cdr (assq 'begin ref))
+                 for end = (if line-only
+                               (save-excursion
+                                (goto-char beg)
+                                (end-of-line)
+                                (point))
+                               (cdr (assq 'end ref)))
+                 do (let ((ovl (make-overlay beg end)))
+                      (overlay-put ovl 'face 'highlight)
+                      (overlay-put ovl 'evaporate t)
+                      (overlay-put ovl 'js2r-highlights t)))
+              (message "%d places highlighted" (length things))
+              (js2r--hl-mode 1))
       (t
        (message "No places found")))))
 
 (defun js2r-hl-rename (pos new-name)
-  (interactive "d\nsRename: ")
-  (let ((places (sort (js2r--highlight-get-regions pos)
+  (interactive "d\nsReplace with: ")
+  (let ((places (sort (js2r--hl-get-regions pos)
                       (lambda (a b)
                         (< (cdr (assq 'begin b))
                            (cdr (assq 'begin a)))))))
@@ -118,7 +180,7 @@
      (message "%d occurrences renamed to %s" (length places) new-name))
     (js2r-hl-forgetit)))
 
-(define-minor-mode js2r--highlight-mode
+(define-minor-mode js2r--hl-mode
   "Internal mode used by `js2r-highlights'"
   nil
   "/•"

--- a/js2r-highlights.el
+++ b/js2r-highlights.el
@@ -90,6 +90,24 @@ this only works if the mode was called with
         (goto-char (overlay-start i))
         (throw 'done nil)))))
 
+(defun js2r-highlight-extend-region ()
+  "Extend region to the current or upper AST node."
+  (interactive)
+  (cond
+    ((use-region-p)
+     (cl-loop
+        for node = (js2-node-at-point (point)) then (js2-node-parent node)
+        for beg = (point) then (js2-node-abs-pos node)
+        for end = (mark) then (js2-node-abs-end node)
+        until (or (< beg (point)) (> end (mark)))
+        finally
+           (goto-char beg)
+           (push-mark end t t)))
+    (t
+     (let ((node (js2-node-at-point (point))))
+       (goto-char (js2-node-abs-pos node))
+       (push-mark (js2-node-abs-end node) t t)))))
+
 (defun js2r--hl-get-var-regions ()
   (let* ((current-node (js2r--local-name-node-at-point))
          (len (js2-node-len current-node)))

--- a/js2r-highlights.el
+++ b/js2r-highlights.el
@@ -1,7 +1,7 @@
 ;;; -*- lexical-binding: t -*-
 ;;; js2r-highlights.el --- Highlight variable occurrences, free variables, etc.
 
-;; Copyright (C) 2016-2017 Mihai Bazon <mihai.bazon@gmail.com>
+;; Copyright (C) 2016-2024 Mihai Bazon <mihai.bazon@gmail.com>
 
 ;; Keywords: conveniences
 
@@ -17,6 +17,57 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This is a minor mode that highlights certain things of interest and
+;; allows you to easily move through them. The most useful is
+;; `js2r-highlight-thing-at-point', which highlights occurrences of
+;; the thing at point. You'd normally use it on variables, and it
+;; selects all occurrences in the defining scope, but it also works on
+;; constants (highlights occurrences in the whole buffer), or on
+;; "this" or "super" keywords.
+;;
+;; There's also `js2r-highlight-free-vars' which selects free
+;; variables in the enclosing function, and `js2r-highlight-exits'
+;; which selects exit points from the current function ("return" or
+;; "throw" nodes).
+;;
+;; While highlights mode is on, the following key bindings are
+;; available:
+;;
+;;     C-<down> - `js2r-highlight-move-next'
+;;     C-<up> - `js2r-highlight-move-prev'
+;;     C-<return> - `js2r-highlight-rename'
+;;     <escape> or C-g - `js2r-highlight-forgetit'
+;;
+;; `js2r-highlight-rename' will replace all highlighted regions with
+;; something else (you'll specify in the minibuffer). When used on
+;; variables it takes care to maintain code semantics, for example in
+;; situations like this:
+;;
+;;     let { foo } = obj;
+;;
+;; With the cursor on "foo", `js2r-highlight-thing-at-point' will
+;; select all occurrences of "foo" in the enclosing scope, and if you
+;; use rename, it will convert to something like this, instead of
+;; simply renaming:
+;;
+;;     let { foo: newName } = obj;
+;;
+;; such that newName will still be initialized to obj.foo, as in the
+;; original code.
+;;
+;; I use the following key bindings to enter highlights mode:
+;;
+;;     (define-key js2-refactor-mode-map (kbd "M-?") 'js2r-highlight-thing-at-point)
+;;     (define-key js2-refactor-mode-map (kbd "C-c C-f") 'js2r-highlight-free-vars)
+;;     (define-key js2-refactor-mode-map (kbd "C-c C-x") 'js2r-highlight-exits)
+;;
+;; There is also an utility function suitable for expand-region, I
+;; have the following in my `js2-mode-hook':
+;;
+;;     (setq er/try-expand-list '(js2r-highlight-extend-region))
 
 ;;; Code:
 

--- a/js2r-highlights.el
+++ b/js2r-highlights.el
@@ -137,7 +137,7 @@ this only works if the mode was called with
     regions))
 
 (defun js2r--hl-get-free-vars-regions (pos undeclared?)
-  (let* ((node (js2-node-at-point pos))
+  (let* ((node (js2-node-at-point pos t))
          (func (js2-mode-find-enclosing-fn node))
          (regions (list)))
     (cl-flet ((is-free? (node)
@@ -169,7 +169,7 @@ this only works if the mode was called with
     regions))
 
 (defun js2r--hl-get-exits-regions (pos)
-  (let* ((node (js2-node-at-point pos))
+  (let* ((node (js2-node-at-point pos t))
          (func (js2-mode-find-parent-fn node))
          (regions (list)))
     (unless func

--- a/js2r-highlights.el
+++ b/js2r-highlights.el
@@ -81,10 +81,19 @@ this only works if the mode was called with
     (save-excursion
      (dolist (p places)
        (let ((begin (cdr (assq 'begin p)))
-             (end (cdr (assq 'end p))))
-         (delete-region begin end)
-         (goto-char begin)
-         (insert new-name)))
+             (end (cdr (assq 'end p)))
+             (node (cdr (assq 'node p))))
+         (cond
+           ((and (js2-name-node-p node)
+                 (js2-object-prop-node-p (js2-node-parent node))
+                 (eq node (js2-object-prop-node-left (js2-node-parent node)))
+                 (eq node (js2-object-prop-node-right (js2-node-parent node))))
+            (goto-char end)
+            (insert ": " new-name))
+           (t
+            (delete-region begin end)
+            (goto-char begin)
+            (insert new-name)))))
      (message "%d occurrences renamed to %s" (length places) new-name))
     (js2r-highlight-forgetit)))
 
@@ -139,7 +148,8 @@ see."
          (len (js2-node-len current-node)))
     (mapcar (lambda (beg)
               `((begin . ,beg)
-                (end . ,(+ beg len))))
+                (end . ,(+ beg len))
+                (node . ,(js2-node-at-point beg))))
             (js2r--local-var-positions current-node t))))
 
 (defun js2r--constant-node-value (node)

--- a/js2r-highlights.el
+++ b/js2r-highlights.el
@@ -1,0 +1,133 @@
+;;; -*- lexical-binding: t -*-
+
+(defun js2r--highlight-get-var-regions ()
+  (let* ((current-node (js2r--local-name-node-at-point))
+         (len (js2-node-len current-node)))
+    (mapcar (lambda (beg)
+              `((begin . ,beg)
+                (end . ,(+ beg len))))
+            (js2r--local-var-positions current-node t))))
+
+(defun js2r--constant-node-value (node)
+  (cond
+    ((js2-number-node-p node) (js2-number-node-value node))
+    ((js2-string-node-p node) (js2-string-node-value node))
+    ((js2-regexp-node-p node) (js2-regexp-node-value node))
+    (t (error "Not a constant node"))))
+
+(defun js2r--highlight-get-constant-regions (const)
+  (let* ((regions (list))
+         (type (js2-node-type const))
+         (value (js2r--constant-node-value const)))
+    (js2-visit-ast js2-mode-ast
+                   (lambda (node end-p)
+                     (unless end-p
+                       (cond
+                         ((and (= type (js2-node-type node))
+                               (equal value (js2r--constant-node-value node)))
+                          (push `((begin . ,(js2-node-abs-pos node))
+                                  (end . ,(js2-node-abs-end node)))
+                                regions))))
+                     t))
+    regions))
+
+(defun js2r--highlight-get-regions (pos)
+  (let ((node (js2-node-at-point pos)))
+    (cond
+      ((js2-name-node-p node) (js2r--highlight-get-var-regions))
+      ((or (js2-string-node-p node)
+           (js2-number-node-p node)
+           (js2-regexp-node-p node))
+       (js2r--highlight-get-constant-regions node)))))
+
+(defun js2r-highlight-thing-at-point (pos)
+  (interactive "d")
+  (js2r-hl-forgetit)
+  (js2r--highlight-things (js2r--highlight-get-regions pos)))
+
+(defun js2r-hl--get-overlays (rev)
+  (sort (remove-if-not (lambda (ov)
+                         (overlay-get ov 'js2r-highlights))
+                       (overlays-in (point-min) (point-max)))
+        (if rev
+            (lambda (a b)
+              (> (overlay-start a) (overlay-start b)))
+            (lambda (a b)
+              (< (overlay-start a) (overlay-start b))))))
+
+(defun js2r-hl-forgetit ()
+  (interactive)
+  (remove-overlays (point-min) (point-max) 'js2r-highlights t)
+  (js2r--highlight-mode 0))
+
+(defun js2r-hl-move-next ()
+  (interactive)
+  (catch 'done
+    (dolist (i (js2r-hl--get-overlays nil))
+      (let ((x (overlay-start i)))
+        (when (> x (point))
+          (goto-char x)
+          (throw 'done nil))))))
+
+(defun js2r-hl-move-prev ()
+  (interactive)
+  (catch 'done
+    (dolist (i (js2r-hl--get-overlays t))
+      (when (< (overlay-end i) (point))
+        (goto-char (overlay-start i))
+        (throw 'done nil)))))
+
+(defun js2r--highlight-things (things &rest options)
+  (let ((line-only (plist-get options :line-only))
+        (things (sort things
+                      (lambda (a b)
+                        (< (cdr (assq 'begin a))
+                           (cdr (assq 'begin b)))))))
+    (cond
+      (things
+       (loop for ref in things
+             for beg = (cdr (assq 'begin ref))
+             for end = (if line-only
+                           (save-excursion
+                            (goto-char beg)
+                            (end-of-line)
+                            (point))
+                           (cdr (assq 'end ref)))
+             do (let ((ovl (make-overlay beg end)))
+                  (overlay-put ovl 'face 'highlight)
+                  (overlay-put ovl 'evaporate t)
+                  (overlay-put ovl 'js2r-highlights t)))
+       (message "%d places highlighted" (length things))
+       (js2r--highlight-mode 1))
+      (t
+       (message "No places found")))))
+
+(defun js2r-hl-rename (pos new-name)
+  (interactive "d\nsRename: ")
+  (let ((places (sort (js2r--highlight-get-regions pos)
+                      (lambda (a b)
+                        (< (cdr (assq 'begin b))
+                           (cdr (assq 'begin a)))))))
+    (save-excursion
+     (dolist (p places)
+       (let ((begin (cdr (assq 'begin p)))
+             (end (cdr (assq 'end p))))
+         (delete-region begin end)
+         (goto-char begin)
+         (insert new-name)))
+     (message "%d occurrences renamed to %s" (length places) new-name))
+    (js2r-hl-forgetit)))
+
+(define-minor-mode js2r--highlight-mode
+  "Internal mode used by `js2r-highlights'"
+  nil
+  "/•"
+  `(
+    (,(kbd "C-<down>") . js2r-hl-move-next)
+    (,(kbd "C-<up>") . js2r-hl-move-prev)
+    (,(kbd "C-<return>") . js2r-hl-rename)
+    (,(kbd "<escape>") . js2r-hl-forgetit)
+    (,(kbd "C-g") . js2r-hl-forgetit)
+    ))
+
+(provide 'js2r-highlights)

--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -70,14 +70,14 @@
    (js2-node-get-enclosing-scope name-node)
    (js2-name-node-name name-node)))
 
-(defun js2r--local-usages-of-name-node (name-node)
+(defun js2r--local-usages-of-name-node (name-node &optional globals-p)
   (unless (js2r--local-name-node-p name-node)
     (error "Node is not on a local identifier"))
   (let* ((name (js2-name-node-name name-node))
          (scope (js2r--name-node-defining-scope name-node))
          (result nil))
     (js2-visit-ast
-     scope
+     (if globals-p (or scope js2-mode-ast) scope)
      (lambda (node end-p)
        (when (and (not end-p)
                   (js2r--local-name-node-p node)
@@ -87,8 +87,8 @@
        t))
     result))
 
-(defun js2r--local-var-positions (name-node)
-  (-map 'js2-node-abs-pos (js2r--local-usages-of-name-node name-node)))
+(defun js2r--local-var-positions (name-node &optional globals-p)
+  (-map 'js2-node-abs-pos (js2r--local-usages-of-name-node name-node globals-p)))
 
 (defun js2r--var-defining-node (var-node)
   (unless (js2r--local-name-node-p var-node)


### PR DESCRIPTION
Here is a little mode that I've been using for years, perhaps others will find it useful. Pasting the [commentary](https://github.com/mishoo/js2-refactor.el/blob/highlights/js2r-highlights.el#L21) below:

```elisp
;; This is a minor mode that highlights certain things of interest and
;; allows you to easily move through them. The most useful is
;; `js2r-highlight-thing-at-point', which highlights occurrences of
;; the thing at point. You'd normally use it on variables, and it
;; selects all occurrences in the defining scope, but it also works on
;; constants (highlights occurrences in the whole buffer), or on
;; "this" or "super" keywords.
;;
;; There's also `js2r-highlight-free-vars' which selects free
;; variables in the enclosing function, and `js2r-highlight-exits'
;; which selects exit points from the current function ("return" or
;; "throw" nodes).
;;
;; While highlights mode is on, the following key bindings are
;; available:
;;
;;     C-<down> - `js2r-highlight-move-next'
;;     C-<up> - `js2r-highlight-move-prev'
;;     C-<return> - `js2r-highlight-rename'
;;     <escape> or C-g - `js2r-highlight-forgetit'
;;
;; `js2r-highlight-rename' will replace all highlighted regions with
;; something else (you'll specify in the minibuffer). When used on
;; variables it takes care to maintain code semantics, for example in
;; situations like this:
;;
;;     let { foo } = obj;
;;
;; With the cursor on "foo", `js2r-highlight-thing-at-point' will
;; select all occurrences of "foo" in the enclosing scope, and if you
;; use rename, it will convert to something like this, instead of
;; simply renaming:
;;
;;     let { foo: newName } = obj;
;;
;; such that newName will still be initialized to obj.foo, as in the
;; original code.
;;
;; I use the following key bindings to enter highlights mode:
;;
;;     (define-key js2-refactor-mode-map (kbd "M-?") 'js2r-highlight-thing-at-point)
;;     (define-key js2-refactor-mode-map (kbd "C-c C-f") 'js2r-highlight-free-vars)
;;     (define-key js2-refactor-mode-map (kbd "C-c C-x") 'js2r-highlight-exits)
;;
;; There is also an utility function suitable for expand-region, I
;; have the following in my `js2-mode-hook':
;;
;;     (setq er/try-expand-list '(js2r-highlight-extend-region))
```